### PR TITLE
各画面の認証機能追加

### DIFF
--- a/lmsc/nuxt-app/features/auth/login/LoginForm.vue
+++ b/lmsc/nuxt-app/features/auth/login/LoginForm.vue
@@ -112,11 +112,25 @@ const handleSubmit = async () => {
       },
       isAuthenticated: true,
     };
+    console.log('isAuthenticated_setBeffore:',userStore.isAuthenticated);
+    console.log('redirectURL_setBeffore:',userStore.redirectPath);
+    console.log('変更した');
     userStore.setUser(user);
-
+    console.log('redirectURL:',userStore.redirectPath);
     console.log('User store after login:', userStore.$state);// ストアの状態をログに出力
 
-    await router.push('/dashboard');
+    // 認証ロジック
+    //await userStore.login(/* ログイン情報 */)
+
+    // ログイン成功後のリダイレクト
+    const test = userStore.redirectPath;
+    console.log('redirectURL:', test);
+    const redirectPath = userStore.redirectPath || '/dashboard'
+    
+    router.push(redirectPath)
+    //userStore.clearRedirectPath()
+
+    //await router.push('/dashboard');
   } catch (error) {
     console.error('Login failed:', error);
   } finally {

--- a/lmsc/nuxt-app/middleware/auth.js
+++ b/lmsc/nuxt-app/middleware/auth.js
@@ -4,6 +4,11 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const userStore = useUserStore()
 
   if (!userStore.isAuthenticated && to.path !== '/login') {
-    return navigateTo('/login')
+    console.log('Redirect path in store_before:', userStore.redirectPath)
+    console.log('Setting redirect path:', to.fullPath)
+    userStore.setRedirectPath(to.fullPath)
+    console.log('Redirect path in store:', userStore.redirectPath)
+    console.log('User store after login:', userStore.$state);// ストアの状態をログに出力
+    return navigateTo(`/login`)
   }
 })

--- a/lmsc/nuxt-app/pages/billingInformation.vue
+++ b/lmsc/nuxt-app/pages/billingInformation.vue
@@ -8,5 +8,8 @@
   </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import BillingInformationList from '~/features/auth/billing/components/BillingInformationList.vue';
 </script>

--- a/lmsc/nuxt-app/pages/dashboard.vue
+++ b/lmsc/nuxt-app/pages/dashboard.vue
@@ -8,5 +8,8 @@
   </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import DashboardContent from '~/features/auth/dashboard/components/DashboardContent.vue';
 </script>

--- a/lmsc/nuxt-app/pages/news/manager/detail.vue
+++ b/lmsc/nuxt-app/pages/news/manager/detail.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import newsDetail from '~/features/news/manager/detail.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/manager/edit/addCategory.vue
+++ b/lmsc/nuxt-app/pages/news/manager/edit/addCategory.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import addCategory from '~/features/news/manager/edit/addCategory.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/manager/edit/addNews.vue
+++ b/lmsc/nuxt-app/pages/news/manager/edit/addNews.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import addNews from '~/features/news/manager/edit/addNews.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/manager/edit/checkNews.vue
+++ b/lmsc/nuxt-app/pages/news/manager/edit/checkNews.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import checkNews from '~/features/news/manager/edit/checkNews.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/manager/edit/editNews.vue
+++ b/lmsc/nuxt-app/pages/news/manager/edit/editNews.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import editNews from '~/features/news/manager/edit/editNews.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/manager/view.vue
+++ b/lmsc/nuxt-app/pages/news/manager/view.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import newsView from '~/features/news/manager/view.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/newsDetail.vue
+++ b/lmsc/nuxt-app/pages/news/newsDetail.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import newsDetail from '~/features/news/newsDetail.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/news/newsView.vue
+++ b/lmsc/nuxt-app/pages/news/newsView.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+})
 import newsView from '~/features/news/newsView.vue'
 </script>
 

--- a/lmsc/nuxt-app/pages/passwordResettings/mailFormLogined.vue
+++ b/lmsc/nuxt-app/pages/passwordResettings/mailFormLogined.vue
@@ -10,5 +10,8 @@
   </div>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import PasswordResettingsMailFormLogined from "~/features/PasswordResettings/PasswordResettingsMailFormLogined.vue";
 </script>

--- a/lmsc/nuxt-app/pages/question.vue
+++ b/lmsc/nuxt-app/pages/question.vue
@@ -8,5 +8,8 @@
     </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import QuestionSummary from '~/features/auth/question/components/QuestionSummary.vue';
 </script>

--- a/lmsc/nuxt-app/pages/questiondetail.vue
+++ b/lmsc/nuxt-app/pages/questiondetail.vue
@@ -8,6 +8,9 @@
     </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import MessageContent from '~/features/auth/question/components/MessageContent.vue';
 
 </script>

--- a/lmsc/nuxt-app/pages/review.vue
+++ b/lmsc/nuxt-app/pages/review.vue
@@ -8,5 +8,8 @@
     </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import ReviewSummary from '~/features/auth/review/components/ReviewSummary.vue';
 </script>

--- a/lmsc/nuxt-app/pages/reviewdetail.vue
+++ b/lmsc/nuxt-app/pages/reviewdetail.vue
@@ -8,6 +8,9 @@
     </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import MessageContent from '~/features/auth/review/components/MessageContent.vue';
 
 </script>

--- a/lmsc/nuxt-app/pages/teamofuse.vue
+++ b/lmsc/nuxt-app/pages/teamofuse.vue
@@ -8,5 +8,8 @@
   </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import TeamOfUseContents from '~/features/auth/userInvitation/TeamOfUseContents.vue'
 </script>

--- a/lmsc/nuxt-app/pages/userInvitation.vue
+++ b/lmsc/nuxt-app/pages/userInvitation.vue
@@ -8,5 +8,8 @@
   </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import UserInvitationForm from '~/features/auth/userInvitation/UserInvitationForm.vue';
 </script>

--- a/lmsc/nuxt-app/pages/userInvitationConfilm.vue
+++ b/lmsc/nuxt-app/pages/userInvitationConfilm.vue
@@ -9,5 +9,8 @@
   </v-container>
 </template>
 <script setup>
+definePageMeta({
+  middleware: 'auth',
+})
 import userInvitationConfilmForm from '~/features/auth/userInvitation/userInvitationConfilmForm.vue'
 </script>

--- a/lmsc/nuxt-app/pages/userInvitationConplete.vue
+++ b/lmsc/nuxt-app/pages/userInvitationConplete.vue
@@ -7,4 +7,8 @@
     <Completed titleText="ユーザー登録が完了しました。" icon="mdi-check-circle" />
   </v-container>
 </template>
-
+<script setup>
+definePageMeta({
+  middleware: 'auth',
+})
+</script>

--- a/lmsc/nuxt-app/store/user.ts
+++ b/lmsc/nuxt-app/store/user.ts
@@ -23,6 +23,7 @@ export const useUserStore = defineStore('user', {
       email: '',
     } as User,
     isAuthenticated: false,
+    redirectPath: '',
   }),
   actions: {
     setUser(payload: Payload) {
@@ -38,6 +39,19 @@ export const useUserStore = defineStore('user', {
         email: '',
       }
       this.isAuthenticated = false
+    },
+    setRedirectPath(path: string) {
+      console.log('setRedirectPath called with:', path)
+      this.redirectPath = path
+      console.log('Redirect path after set:', this.redirectPath)
+    },
+    login(/* ログイン情報 */) {
+      // 認証ロジック
+      this.isAuthenticated = true
+      console.log("loginメソッド");
+    },
+    clearRedirectPath() {
+      this.redirectPath = ''
     },
   },
   getters: {


### PR DESCRIPTION
・各画面に認証機能を追加
・ログイン後にもともと遷移しようとしていたURLにリダイレクトする処理を追加（まだ動いていない）

## やったこと

-レビューが終わって公開されているpagesに認証機能を追加（ログインしていない場合はログインページに遷移するようにしてあります。）

## やっていないこと

-各画面から認証のためログインページに遷移した後、ログイン情報を入力し、もともと遷移しようとしていた画面にリダイレクトする機能の追加（ログイン画面に行く前にリダイレクト情報が保存はできているが、リダイレクトするタイミングで保存されているはずの情報がない不具合が発生）

## 動作確認

-

## その他

-
